### PR TITLE
Hotfix/fuzzy image search

### DIFF
--- a/replacer.go
+++ b/replacer.go
@@ -38,36 +38,36 @@ func replaceLibrary(content string) string {
 	return strings.Replace(content, "@Library('ods-jenkins-shared-library@3.x') _", "@Library('ods-jenkins-shared-library@4.x') _", -1)
 }
 
+// This attempts to change images that follows the pattern "ods/jenkins-agent*". The method considers single and double quoted
+// values as well as prevents from panicking. Instead, the image should be left as is and it will advice to manually check it
+// Note: this is considered a temporary solution to the problem faced with Jenkinsfiles
 func replaceAgentImages(content string) string {
-	re := regexp.MustCompile(`'ods/jenkins-agent-(.*):.*'`)
 
-	matches := re.FindAllStringSubmatch(content, -1)
-	return fmt.Sprintf("Returned value: %q. Argument passed: %q", matches, content)
+	reSingle := regexp.MustCompile(`'ods/jenkins-agent-(.*):.*'`)
+	matches := reSingle.FindAllStringSubmatch(content, -1)
 
-	fmt.Println(matches[0][1])
-	if string(matches[0][1]) == "nodejs10-angular" {
-		return re.ReplaceAllString(content, "'ods/jenkins-agent-nodejs12:4.x'")
-	}
-
-	return re.ReplaceAllString(content, "'ods/jenkins-agent-$1:4.x'")
-}
-
-// At the moment, this attempts to only change images from ods/jenkins-agent* and should leave the rest as is
-// If no change is made, it will inform to manually check it
-func replaceAgentImagesFuzzy(content string) string {
-	re := regexp.MustCompile(`['"]?ods/jenkins-agent-(.*):.*['"]?`)
-
-	matches := re.FindAllStringSubmatch(content, -1)
 	if matches != nil {
-		fmt.Println(matches[0][1])
 		if string(matches[0][1]) == "nodejs10-angular" {
-			return re.ReplaceAllString(content, "'ods/jenkins-agent-nodejs12:4.x'")
+			return reSingle.ReplaceAllString(content, "'ods/jenkins-agent-nodejs12:4.x'")
 		}
 
-		return re.ReplaceAllString(content, "ods/jenkins-agent-$1:4.x")
+		return reSingle.ReplaceAllString(content, "'ods/jenkins-agent-$1:4.x'")
+
+	} else {
+
+		reDouble := regexp.MustCompile(`"ods/jenkins-agent-(.*):.*"`)
+		matches := reDouble.FindAllStringSubmatch(content, -1)
+
+		if matches != nil {
+			if string(matches[0][1]) == "nodejs10-angular" {
+				return reDouble.ReplaceAllString(content, "\"ods/jenkins-agent-nodejs12:4.x\"")
+			}
+
+			return reDouble.ReplaceAllString(content, "\"ods/jenkins-agent-$1:4.x\"")
+		}
 	}
 
-	fmt.Println("Warning: No canonical image found. Please, consider if there is an image that should also be migrated to version 4.x")
+	fmt.Printf("Warning: No canonical image found, such as this pattern :'ods/jenkins-agent-*'. \nPlease, consider if there is an image that should also be migrated to ODS version 4.\n")
 	return content
 }
 

--- a/replacer.go
+++ b/replacer.go
@@ -42,12 +42,33 @@ func replaceAgentImages(content string) string {
 	re := regexp.MustCompile(`'ods/jenkins-agent-(.*):.*'`)
 
 	matches := re.FindAllStringSubmatch(content, -1)
+	return fmt.Sprintf("Returned value: %q. Argument passed: %q", matches, content)
+
 	fmt.Println(matches[0][1])
 	if string(matches[0][1]) == "nodejs10-angular" {
 		return re.ReplaceAllString(content, "'ods/jenkins-agent-nodejs12:4.x'")
 	}
 
 	return re.ReplaceAllString(content, "'ods/jenkins-agent-$1:4.x'")
+}
+
+// At the moment, this attempts to only change images from ods/jenkins-agent* and should leave the rest as is
+// If no change is made, it will inform to manually check it
+func replaceAgentImagesFuzzy(content string) string {
+	re := regexp.MustCompile(`['"]?ods/jenkins-agent-(.*):.*['"]?`)
+
+	matches := re.FindAllStringSubmatch(content, -1)
+	if matches != nil {
+		fmt.Println(matches[0][1])
+		if string(matches[0][1]) == "nodejs10-angular" {
+			return re.ReplaceAllString(content, "'ods/jenkins-agent-nodejs12:4.x'")
+		}
+
+		return re.ReplaceAllString(content, "ods/jenkins-agent-$1:4.x")
+	}
+
+	fmt.Println("Warning: No canonical image found. Please, consider if there is an image that should also be migrated to version 4.x")
+	return content
 }
 
 func replaceComponentStageImport(content string) string {

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -68,37 +68,33 @@ func readFile(goldenFile string) string {
 	return string(want)
 }
 
-// At the moment, we expect three changes to take place in this test suite, one result should be blank without panicking (relman)
-// and the rest should be left the same because they are concrete images
+// The focus has been: matching patterns, quotes, duplicity of images, combination of them
 func TestTableReplaceAgentImages(t *testing.T) {
 
 	testsDouble := []struct {
 		input    string
 		expected string
 	}{
-		{input: "alpha/jenkins-agent-nodejs10-angular:3.x", expected: "\"alpha/jenkins-agent-nodejs10-angular:3.x\""},
-		{input: "ods/jenkins-agent-maven:3.0.0", expected: "\"ods/jenkins-agent-maven:4.x\""},
 		{input: "ods/jenkins-agent-base:3.0.0", expected: "\"ods/jenkins-agent-base:4.x\""},
 		{input: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "\"${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0\""},
 		{input: "ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "\"ods/jenkins-agent-nodejs12:4.x\""},
 		{input: "odsalpha/jenkins-agent-nodejs10-angular:3.x", expected: "\"odsalpha/jenkins-agent-nodejs10-angular:3.x\""},
 		{input: "odsalpha/jenkins-agent-base:3.x", expected: "\"odsalpha/jenkins-agent-base:3.x\""},
 		{input: "", expected: "\"\""},
-		{input: "odsalpha/jenkins-agent-terraform:3.x", expected: "\"odsalpha/jenkins-agent-terraform:3.x\""},
 		{input: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest", expected: "\"${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest\""},
 	}
 
 	fmt.Println()
-	t.Logf("####################################")
-	t.Logf("## Test suite doble quoted values ##")
-	t.Logf("####################################\n")
+	t.Logf("#####################################")
+	t.Logf("## Test suite double quoted values ##")
+	t.Logf("#####################################\n")
 	fmt.Println()
 	for _, test := range testsDouble {
-		dobleQuoted := fmt.Sprintf("%q", test.input)
-		if output := replaceAgentImages(dobleQuoted); output != test.expected {
-			t.Errorf("FAILED; input: %q, expected %q, received: %q.", dobleQuoted, test.expected, output)
+		doubleQuoted := fmt.Sprintf("%q", test.input)
+		if output := replaceAgentImages(doubleQuoted); output != test.expected {
+			t.Errorf("FAILED; input: %v, expected: %v, received: %v.", doubleQuoted, test.expected, output)
 		} else {
-			t.Logf("PASSED; input: %q, expected %q, received: %q", dobleQuoted, test.expected, output)
+			t.Logf("PASSED; input: %v, expected: %v, received: %v", doubleQuoted, test.expected, output)
 		}
 	}
 
@@ -108,16 +104,14 @@ func TestTableReplaceAgentImages(t *testing.T) {
 	}{
 		{input: "alpha/jenkins-agent-nodejs10-angular:3.x", expected: "'alpha/jenkins-agent-nodejs10-angular:3.x'"},
 		{input: "ods/jenkins-agent-maven:3.0.0", expected: "'ods/jenkins-agent-maven:4.x'"},
-		{input: "ods/jenkins-agent-base:3.0.0", expected: "'ods/jenkins-agent-base:4.x'"},
 		{input: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "'${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'"},
 		{input: "ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "'ods/jenkins-agent-nodejs12:4.x'"},
-		{input: "odsalpha/jenkins-agent-nodejs10-angular:3.x", expected: "'odsalpha/jenkins-agent-nodejs10-angular:3.x'"},
-		{input: "odsalpha/jenkins-agent-base:3.x", expected: "'odsalpha/jenkins-agent-base:3.x'"},
 		{input: "", expected: "''"},
 		{input: "odsalpha/jenkins-agent-terraform:3.x", expected: "'odsalpha/jenkins-agent-terraform:3.x'"},
 		{input: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest", expected: "'${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'"},
 	}
 
+	fmt.Println()
 	fmt.Println()
 	t.Logf("#####################################")
 	t.Logf("## Test suite single quoted values ##")
@@ -126,10 +120,40 @@ func TestTableReplaceAgentImages(t *testing.T) {
 	for _, test := range testsSingle {
 		singleQuoted := fmt.Sprintf("'%v'", test.input)
 		if output := replaceAgentImages(singleQuoted); output != test.expected {
-			t.Errorf("FAILED; input: %q, expected %q, received: %q.", singleQuoted, test.expected, output)
+			t.Errorf("FAILED; input: %v, expected: %v, received: %v.", singleQuoted, test.expected, output)
 		} else {
-			t.Logf("PASSED; input: %q, expected %q, received: %q", singleQuoted, test.expected, output)
+			t.Logf("PASSED; input: %v, expected: %v, received: %v", singleQuoted, test.expected, output)
 		}
 	}
 
+	testsMultiLines := []struct {
+		input    string
+		expected string
+	}{
+		{input: " 'alpha/jenkins-agent-nodejs10-angular:3.x'\n 'alpha/jenkins-agent-nodejs10-angular:3.x'\n", expected: " 'alpha/jenkins-agent-nodejs10-angular:3.x'\n 'alpha/jenkins-agent-nodejs10-angular:3.x'\n"},
+		{input: " 'ods/jenkins-agent-maven:3.0.0'\n 'ods/jenkins-agent-maven:3.0.0'\n", expected: " 'ods/jenkins-agent-maven:4.x'\n 'ods/jenkins-agent-maven:4.x'\n"},
+		{input: " 'ods/jenkins-agent-base:3.0.0'\n 'ods/jenkins-agent-base:4.x'\n", expected: " 'ods/jenkins-agent-base:4.x'\n 'ods/jenkins-agent-base:4.x'\n"},
+		{input: " 'ods/jenkins-agent-base:4.x'\n 'ods/jenkins-agent-base:3.0.0'\n", expected: " 'ods/jenkins-agent-base:4.x'\n 'ods/jenkins-agent-base:4.x'\n"},
+		{input: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n", expected: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n"},
+		{input: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs12-angular:4.x'\n", expected: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs12-angular:4.x'\n"},
+		{input: " 'ods/jenkins-agent-nodejs10-angular:3.0.0'\n 'ods/jenkins-agent-nodejs12:4.x'\n", expected: " 'ods/jenkins-agent-nodejs12:4.x'\n 'ods/jenkins-agent-nodejs12:4.x'\n"},
+		{input: " 'ods/jenkins-agent-nodejs12:4.x'\n 'ods/jenkins-agent-nodejs10-angular:3.0.0'\n", expected: " 'ods/jenkins-agent-nodejs12:4.x'\n 'ods/jenkins-agent-nodejs12:4.x'\n"},
+		{input: " '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n", expected: " '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n"},
+	}
+
+	fmt.Println()
+	fmt.Println()
+	t.Logf("######################################")
+	t.Logf("## Test suite multiple lines values ##")
+	t.Logf("######################################\n")
+	fmt.Println()
+	for _, test := range testsMultiLines {
+		multiLine := fmt.Sprintf("%v", test.input)
+		fmt.Println()
+		if output := replaceAgentImages(multiLine); output != test.expected {
+			t.Errorf("FAILED; input: %v, expected: %v, received: %v.", multiLine, test.expected, output)
+		} else {
+			t.Logf("PASSED; input: %v, expected: %v, received: %v", multiLine, test.expected, output)
+		}
+	}
 }

--- a/replacer_test.go
+++ b/replacer_test.go
@@ -48,7 +48,7 @@ func TestReplace(t *testing.T) {
 
 			converted, err := ioutil.ReadFile(tt.args.convertedFile)
 			if err != nil {
-				t.Errorf("failed to open file: %w", err)
+				t.Errorf("failed to open file: %v", err)
 			}
 
 			if got := string(converted); got != string(tt.want) {
@@ -66,4 +66,63 @@ func readFile(goldenFile string) string {
 	}
 
 	return string(want)
+}
+
+// We expect to fail here almost in all cases, except for ods/jenkins-agent-* images
+// It has also the problem of the single quotes in the pattern
+func TestTableReplaceAgentImages(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "'ods/jenkins-agent-nodejs12-angular:4.x'"},
+		{input: "ods/jenkins-agent-maven:3.0.0", expected: "'ods/jenkins-agent-maven:4.x'"},
+		{input: "ods/jenkins-agent-base:3.0.0", expected: "'ods/jenkins-agent-base:4.x'"},
+		{input: "", expected: ""},
+		{input: "alpha/jenkins-agent-nodejs10-angular:3.x", expected: "alpha/jenkins-agent-nodejs10-angular:3.x"},
+		{input: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0"},
+		{input: "odsalpha/jenkins-agent-nodejs10-angular:3.x", expected: "odsalpha/jenkins-agent-nodejs10-angular:3.x"},
+		{input: "odsalpha/jenkins-agent-base:3.x", expected: "odsalpha/jenkins-agent-base:3.x"},
+		{input: "odsalpha/jenkins-agent-terraform:3.x", expected: "odsalpha/jenkins-agent-terraform:3.x"},
+		{input: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest", expected: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest"},
+	}
+
+	for _, test := range tests {
+		if output := replaceAgentImages(test.input); output != test.expected {
+			t.Errorf("TestTableReplaceAgentImages FAILED; input: %q, expected %q, received: %q", test.input, test.expected, output)
+		} else {
+			t.Logf("TestTableReplaceAgentImages PASSED; input: %q, expected %q, received: %q", test.input, test.expected, output)
+		}
+	}
+}
+
+// At the moment we expect three changes to take place in this test suite, one blank without panic (relman)
+// and the rest to be left the same because they are concrete images
+func TestTableReplaceAgentImagesFuzzy(t *testing.T) {
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{input: "alpha/jenkins-agent-nodejs10-angular:3.x", expected: "alpha/jenkins-agent-nodejs10-angular:3.x"},
+		{input: "ods/jenkins-agent-maven:3.0.0", expected: "ods/jenkins-agent-maven:4.x"},
+		{input: "ods/jenkins-agent-base:3.0.0", expected: "ods/jenkins-agent-base:4.x"},
+		{input: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0"},
+		{input: "ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "'ods/jenkins-agent-nodejs12:4.x'"},
+		{input: "odsalpha/jenkins-agent-nodejs10-angular:3.x", expected: "odsalpha/jenkins-agent-nodejs10-angular:3.x"},
+		{input: "odsalpha/jenkins-agent-base:3.x", expected: "odsalpha/jenkins-agent-base:3.x"},
+		{input: "", expected: ""},
+		{input: "odsalpha/jenkins-agent-terraform:3.x", expected: "odsalpha/jenkins-agent-terraform:3.x"},
+		{input: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest", expected: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest"},
+	}
+
+	for _, test := range tests {
+		if output := replaceAgentImagesFuzzy(test.input); output != test.expected {
+			t.Errorf("TestTableReplaceAgentImages FAILED; input: %q, expected %q, received: %q.", test.input, test.expected, output)
+		} else {
+			t.Logf("TestTableReplaceAgentImages PASSED; input: %q, expected %q, received: %q", test.input, test.expected, output)
+		}
+	}
+
 }


### PR DESCRIPTION
This attempts to help making changes to Jenkinsfiles. 

- Context
While working in the ODS migration, we found out that this program, although helpful, panicked for various reasons: https://github.com/opendevstack/ods-jenkinsfile-converter/issues/5 

- Change
In an attempt for doing the program more resilient, the method 'replaceAgentImages' has been changed and some unit tests were also added.

It would be great if somebody could merge this or could give me some feedback to improve the quality of the commit, since we will try to build upon this program and automate other processes.

Best regards,