### PR TITLE
fix bug replacing agent images

### DIFF
--- a/replacer_test.go
+++ b/replacer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 )
@@ -16,8 +17,7 @@ func TestReplace(t *testing.T) {
 		args args
 		want string
 	}{
-		{
-			name: "Stage Rollout Single Line",
+		{name: "Stage Rollout Single Line",
 			args: args{
 				inputFile:     "internal/test/stage-rollout-single-line/Jenkinsfile",
 				convertedFile: "internal/test/stage-rollout-single-line/out/Jenkinsfile",
@@ -48,7 +48,7 @@ func TestReplace(t *testing.T) {
 
 			converted, err := ioutil.ReadFile(tt.args.convertedFile)
 			if err != nil {
-				t.Errorf("failed to open file: %w", err)
+				t.Errorf("failed to open file: %v", err)
 			}
 
 			if got := string(converted); got != string(tt.want) {
@@ -66,4 +66,94 @@ func readFile(goldenFile string) string {
 	}
 
 	return string(want)
+}
+
+// The focus has been: matching patterns, quotes, duplicity of images, combination of them
+func TestTableReplaceAgentImages(t *testing.T) {
+
+	testsDouble := []struct {
+		input    string
+		expected string
+	}{
+		{input: "ods/jenkins-agent-base:3.0.0", expected: "\"ods/jenkins-agent-base:4.x\""},
+		{input: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "\"${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0\""},
+		{input: "ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "\"ods/jenkins-agent-nodejs12:4.x\""},
+		{input: "odsalpha/jenkins-agent-nodejs10-angular:3.x", expected: "\"odsalpha/jenkins-agent-nodejs10-angular:3.x\""},
+		{input: "odsalpha/jenkins-agent-base:3.x", expected: "\"odsalpha/jenkins-agent-base:3.x\""},
+		{input: "", expected: "\"\""},
+		{input: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest", expected: "\"${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest\""},
+	}
+
+	fmt.Println()
+	t.Logf("#####################################")
+	t.Logf("## Test suite double quoted values ##")
+	t.Logf("#####################################\n")
+	fmt.Println()
+	for _, test := range testsDouble {
+		doubleQuoted := fmt.Sprintf("%q", test.input)
+		if output := replaceAgentImages(doubleQuoted); output != test.expected {
+			t.Errorf("FAILED; input: %v, expected: %v, received: %v.", doubleQuoted, test.expected, output)
+		} else {
+			t.Logf("PASSED; input: %v, expected: %v, received: %v", doubleQuoted, test.expected, output)
+		}
+	}
+
+	testsSingle := []struct {
+		input    string
+		expected string
+	}{
+		{input: "alpha/jenkins-agent-nodejs10-angular:3.x", expected: "'alpha/jenkins-agent-nodejs10-angular:3.x'"},
+		{input: "ods/jenkins-agent-maven:3.0.0", expected: "'ods/jenkins-agent-maven:4.x'"},
+		{input: "${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "'${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'"},
+		{input: "ods/jenkins-agent-nodejs10-angular:3.0.0", expected: "'ods/jenkins-agent-nodejs12:4.x'"},
+		{input: "", expected: "''"},
+		{input: "odsalpha/jenkins-agent-terraform:3.x", expected: "'odsalpha/jenkins-agent-terraform:3.x'"},
+		{input: "${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest", expected: "'${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'"},
+	}
+
+	fmt.Println()
+	fmt.Println()
+	t.Logf("#####################################")
+	t.Logf("## Test suite single quoted values ##")
+	t.Logf("#####################################\n")
+	fmt.Println()
+	for _, test := range testsSingle {
+		singleQuoted := fmt.Sprintf("'%v'", test.input)
+		if output := replaceAgentImages(singleQuoted); output != test.expected {
+			t.Errorf("FAILED; input: %v, expected: %v, received: %v.", singleQuoted, test.expected, output)
+		} else {
+			t.Logf("PASSED; input: %v, expected: %v, received: %v", singleQuoted, test.expected, output)
+		}
+	}
+
+	testsMultiLines := []struct {
+		input    string
+		expected string
+	}{
+		{input: " 'alpha/jenkins-agent-nodejs10-angular:3.x'\n 'alpha/jenkins-agent-nodejs10-angular:3.x'\n", expected: " 'alpha/jenkins-agent-nodejs10-angular:3.x'\n 'alpha/jenkins-agent-nodejs10-angular:3.x'\n"},
+		{input: " 'ods/jenkins-agent-maven:3.0.0'\n 'ods/jenkins-agent-maven:3.0.0'\n", expected: " 'ods/jenkins-agent-maven:4.x'\n 'ods/jenkins-agent-maven:4.x'\n"},
+		{input: " 'ods/jenkins-agent-base:3.0.0'\n 'ods/jenkins-agent-base:4.x'\n", expected: " 'ods/jenkins-agent-base:4.x'\n 'ods/jenkins-agent-base:4.x'\n"},
+		{input: " 'ods/jenkins-agent-base:4.x'\n 'ods/jenkins-agent-base:3.0.0'\n", expected: " 'ods/jenkins-agent-base:4.x'\n 'ods/jenkins-agent-base:4.x'\n"},
+		{input: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n", expected: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n"},
+		{input: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs12-angular:4.x'\n", expected: " '${dockerRegistry}/ods/jenkins-agent-nodejs10-angular:3.0.0'\n '${dockerRegistry}/ods/jenkins-agent-nodejs12-angular:4.x'\n"},
+		{input: " 'ods/jenkins-agent-nodejs10-angular:3.0.0'\n 'ods/jenkins-agent-nodejs12:4.x'\n", expected: " 'ods/jenkins-agent-nodejs12:4.x'\n 'ods/jenkins-agent-nodejs12:4.x'\n"},
+		{input: " 'ods/jenkins-agent-nodejs12:4.x'\n 'ods/jenkins-agent-nodejs10-angular:3.0.0'\n", expected: " 'ods/jenkins-agent-nodejs12:4.x'\n 'ods/jenkins-agent-nodejs12:4.x'\n"},
+		{input: " '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n", expected: " '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n '${dockerRegistry}/edpp-cd/jenkins-agent-maven-chrome:latest'\n"},
+	}
+
+	fmt.Println()
+	fmt.Println()
+	t.Logf("######################################")
+	t.Logf("## Test suite multiple lines values ##")
+	t.Logf("######################################\n")
+	fmt.Println()
+	for _, test := range testsMultiLines {
+		multiLine := fmt.Sprintf("%v", test.input)
+		fmt.Println()
+		if output := replaceAgentImages(multiLine); output != test.expected {
+			t.Errorf("FAILED; input: %v, expected: %v, received: %v.", multiLine, test.expected, output)
+		} else {
+			t.Logf("PASSED; input: %v, expected: %v, received: %v", multiLine, test.expected, output)
+		}
+	}
 }


### PR DESCRIPTION
This attempts to help making changes to Jenkinsfiles.

- Context
While working in the ODS migration, we found out that this program, although helpful, panicked for various reasons. One of them can be seen here: https://github.com/opendevstack/ods-jenkinsfile-converter/issues/5

- Change
In an attempt for doing the program more resilient, the method 'replaceAgentImages' has been changed and some unit tests were also added.

It would be great if somebody could merge this or could give me some feedback to improve the quality of the commit, since we will try to build upon this program and automate other processes.

Note: I've closed the previous pull request (https://github.com/opendevstack/ods-jenkinsfile-converter/pull/7) because I think that the history is cleaner and more meaningful this way, and I've changed a variable in the anonymous function too.

Best regards,
thanks for your time